### PR TITLE
Add config variable for the cert directory.

### DIFF
--- a/hpkpinx.sh
+++ b/hpkpinx.sh
@@ -4,6 +4,7 @@ set -e
 
 NGINX_ROOT='/etc/nginx'
 HPKPINX_ROOT='/opt/hpkpinx'
+CERT_ROOT="${NGINX_ROOT}/certs"
 
 . ${HPKPINX_ROOT}/config.sh
 
@@ -58,7 +59,7 @@ then
         echo -n "add_header Public-Key-Pins-Report-Only '" > ${NGINX_ROOT}/hpkp.conf
     fi
     echo -n "pin-sha256=\"${STATIC_PIN}\"; " >> ${NGINX_ROOT}/hpkp.conf
-    generate_pin "${NGINX_ROOT}/certs/${2}/privkey.pem" >> ${NGINX_ROOT}/hpkp.conf
-    generate_pin "${NGINX_ROOT}/certs/${2}/privkey.roll.pem" >> ${NGINX_ROOT}/hpkp.conf
+    generate_pin "${CERT_ROOT}/${2}/privkey.pem" >> ${NGINX_ROOT}/hpkp.conf
+    generate_pin "${CERT_ROOT}/${2}/privkey.roll.pem" >> ${NGINX_ROOT}/hpkp.conf
     echo "max-age=${HPKP_AGE}';" >> ${NGINX_ROOT}/hpkp.conf
 fi

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,11 @@ include hpkp.conf;
 
 The config file is located at `/opt/hpkpinx/config.sh`. You have the following options:
 
+### CERT_ROOT
+
+The path to the folder where dehydrated is putting the Certs (eg. $CERTDIR from the dehydrated config).
+This is Optional, defaults to certs in the nginx folder.
+
 ### HPKP_AGE
 
 The time, in seconds, that the browser should remember that this site is only to be accessed using one of the defined keys.


### PR DESCRIPTION
This config variable will make it possible to have the certs stored
in an directory not inside of the nginx config. Defaults to the
privious behaviour.