### PR TITLE
Allow multiple certificates to be handeld

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,23 @@ In this case, you can generate a pin for your private key with:
 hpkpinx.sh generate_pin <your_key.pem>
 ~~~
 
+### MULTIPLE_HPKP_CONF
+
+If this config value is set to `1` it will generate an nginx hkpk config file for for each Certificate. 
+This is normally needed if more than one Key is in use.
+
+### STATIC_PIN_FILE
+
+An File to get the STATIC_PIN value for different Certificate CNs. This is used to have an seperat backup Key for each Certificate
+The format should be the CN of the certificat, an space and then the PIN:
+
+~~~
+example.com 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+test.example.net 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+~~~
+
+If this Option is used, `MULTIBLE_HPKP_CONF` should be enabled too in most cases.
+
 ### DEPLOY_HPKP
 
 * If set to `0` (the default), Nginx will only send the `Public-Key-Pins-Report-Only` header and HPKP is not applied.


### PR DESCRIPTION
The first new option MULTIBLE_HPKP_CONF tells the script to generate the nginx
config file name from the common name of the certificate currently
handled. This allow the script to handle more than one Domain with different
private keys.

The second new config variable STATIC_PIN_FILE  allows it to define a file
from which the STATIC_PIN for each common name is read. This basically allows
it to have an different backup key per CN. The file is organized line wise separated by
space the CN and the HPKP static pin.